### PR TITLE
Fixing fontconfig.h import issues for MacOS users

### DIFF
--- a/xpdf/GlobalParams.cc
+++ b/xpdf/GlobalParams.cc
@@ -24,7 +24,11 @@
 #include <paper.h>
 #endif
 #if HAVE_FONTCONFIG
-#  include <fontconfig/fontconfig.h>
+#  if __APPLE__
+#     include </usr/local/include/fontconfig/fontconfig.h>
+#  else
+#     include <fontconfig/fontconfig.h>
+#endif
 #endif
 #include "gmem.h"
 #include "gmempp.h"


### PR DESCRIPTION
**Context**
As per the [following issue](https://github.com/kermitt2/pdfalto/issues/135), Mac users have been repeatedly encountering issues with `fontconfig.h` while running the `make` command. The proposed solution in the issue thread was to change the CMakeLists file. 
**Changes**
This PR proposes another solution, which is to detect the Apple OS from the compiler macros, thereby changing the path to `fontconfig` based on the user's OS directly in the file where fontconfig is included.